### PR TITLE
Correct a comment of GPBFieldDescriptor

### DIFF
--- a/objectivec/GPBDescriptor.h
+++ b/objectivec/GPBDescriptor.h
@@ -182,7 +182,7 @@ typedef NS_ENUM(uint8_t, GPBFieldType) {
 @property(nonatomic, readonly, getter=isOptional) BOOL optional;
 /** Type of field (single, repeated, map). */
 @property(nonatomic, readonly) GPBFieldType fieldType;
-/** Type of the key if the field is a map. The value's type is -fieldType. */
+/** Type of the key if the field is a map. The value's type is -dataType. */
 @property(nonatomic, readonly) GPBDataType mapKeyDataType;
 /** Whether the field is packable. */
 @property(nonatomic, readonly, getter=isPackable) BOOL packable;


### PR DESCRIPTION
The comment of property 'mapKeyDataType' has a mistake.
If the field is a map, the value's type is not fieldType.
Instead, it's dataType.

e.g. The following case is a field of Int32-String Map.

<img width="268" alt="image" src="https://user-images.githubusercontent.com/17724564/119452614-2383fb80-bd69-11eb-93f7-a677e9a96749.png">
